### PR TITLE
アイテム一覧表示。新規アイテム登録時のラジオボタンをscript処理に変更

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -24,7 +24,7 @@ class ItemsController < ApplicationController
 
   # POST /items or /items.json
   def create
-    @item = Item.new(item_params.except(:quantity, :remark))
+    @item = Item.new(item_params)
     item_type = params[:item][:item_type]
     quantity = params[:item][:quantity]
     remark = params[:item][:remark]
@@ -92,7 +92,7 @@ class ItemsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def item_params
-      params.require(:item).permit(:name, :character, :category, :purchased_on, :image, :item_type, :quantity, :remark)
+      params.require(:item).permit(:name, :character, :category, :purchased_on, :image)
     end
 
     def update_or_build_item(item_type, quantity, remark)

--- a/app/controllers/owned_items_controller.rb
+++ b/app/controllers/owned_items_controller.rb
@@ -4,6 +4,7 @@ class OwnedItemsController < ApplicationController
   # GET /owned_items or /owned_items.json
   def index
     @owned_items = OwnedItem.all
+    @items = Item.includes(:owned_item).where.not(owned_items: { id: nil })
   end
 
   # GET /owned_items/1 or /owned_items/1.json
@@ -21,6 +22,7 @@ class OwnedItemsController < ApplicationController
 
   # POST /owned_items or /owned_items.json
   def create
+    @item = Item.find(params[:item_id])
     @owned_item = OwnedItem.new(owned_item_params)
 
     respond_to do |format|

--- a/app/controllers/wanted_items_controller.rb
+++ b/app/controllers/wanted_items_controller.rb
@@ -4,6 +4,7 @@ class WantedItemsController < ApplicationController
   # GET /wanted_items or /wanted_items.json
   def index
     @wanted_items = WantedItem.all
+    @items = Item.includes(:wanted_item).where.not(wanted_items: { id: nil })
   end
 
   # GET /wanted_items/1 or /wanted_items/1.json
@@ -21,11 +22,12 @@ class WantedItemsController < ApplicationController
 
   # POST /wanted_items or /wanted_items.json
   def create
-    @wanted_item = WantedItem.new(wanted_item_params)
+    @item = Item.find(params[:item_id])
+    @wanted_item = @item.wanted_items.build(wanted_item_params)
 
     respond_to do |format|
       if @wanted_item.save
-        format.html { redirect_to wanted_item_url(@wanted_item), notice: "Wanted item was successfully created." }
+        format.html { redirect_to @item, notice: "Wanted item was successfully created." }
         format.json { render :show, status: :created, location: @wanted_item }
       else
         format.html { render :new, status: :unprocessable_entity }

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -12,22 +12,22 @@ class Item < ApplicationRecord
   validates :category, presence:true
   validates :purchased_on, presence:true
 
-  validate :item_type_selection
-  validate :quantity_presence
+  # validate :item_type_selection
+  # # validate :quantity_presence
 
-  private
+  # private
 
-  def item_type_selection
-    unless owned_item || wanted_item
-      errors.add(:base, "Item type must be selected.")
-    end
-  end
+  # def item_type_selection
+  #   unless owned_item || wanted_item
+  #     errors.add(:base, "Item type must be selected.")
+  #   end
+  # end
 
-  def quantity_presence
-    if owned_item && owned_item.quantity.blank?
-      errors.add(:base, "Quantity must be provided for owned item.")
-    elsif wanted_item && wanted_item.quantity.blank?
-      errors.add(:base, "Quantity must be provided for wanted item.") 
-    end
-  end
+  # def quantity_presence
+  #   if owned_item && owned_item.quantity.blank?
+  #     errors.add(:base, "Quantity must be provided for owned item.")
+  #   elsif wanted_item && wanted_item.quantity.blank?
+  #     errors.add(:base, "Quantity must be provided for wanted item.") 
+  #   end
+  # end
 end

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -37,16 +37,17 @@
     <%= form.text_field :image %>
   </div>
 
-  <div class="field">
-    <%= form.label :item_type, "Item type" %><br>
+  <div form id="field">
+    <%= form.label :item_type, 'Item type' %><br>
 
-    <%= label_tag('item_type_owned', 'Owned item') %>
-    <%= radio_button_tag('item_type', 'owned') %> 
+    <%= form.label :item_type_owned, 'Owned item' %>
+    <%= form.radio_button :item_type, 'owned', onchange: "updateFormAction();"%>
    
-    <%= label_tag('item_type_wanted', 'Wanted item')%>
-    <%= radio_button_tag('item_type', 'wanted') %>
-   
+    <%= form.label :item_type_wanted, 'Wanted item' %>
+    <%= form.radio_button :item_type, 'wanted', onchange: "updateFormAction();" %>
+    
   </div>
+
 
   <div class="field">
     <%= form.label :quantity %>
@@ -64,4 +65,15 @@
   </div>
 <% end %>
 
+<script>
+  function updateFormAction() {
+    var form = document.getElementById('itemForm');
+    var itemType = document.querySelector('input[name="item_type"]:checked').value;
+    if (itemType == 'owned') {
+      form.action = '/owned_items';
+    } else if (itemType == 'wanted') {
+      form.action = '/wanted_items';
+    }
+  }
+</script>
 

--- a/app/views/owned_items/index.html.erb
+++ b/app/views/owned_items/index.html.erb
@@ -5,17 +5,22 @@
 <table>
   <thead>
     <tr>
-      <th>Quantity</th>
-      <th>Remark</th>
+      <th>Image</th>
+      <th>Name</th>
+      <th>Character</th>
+      <th>Category</th>
+
       <th colspan="3"></th>
     </tr>
   </thead>
 
   <tbody>
-    <% @owned_items.each do |owned_item| %>
+    <% @items.each do |item| %>
       <tr>
-        <td><%= owned_item.quantity %></td>
-        <td><%= owned_item.remark %></td>
+        <td><%= item.image %></td>
+        <td><%= item.name %></td>
+        <td><%= item.character %></td>
+        <td><%= item.category %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/wanted_items/index.html.erb
+++ b/app/views/wanted_items/index.html.erb
@@ -5,17 +5,22 @@
 <table>
   <thead>
     <tr>
-      <th>Quantity</th>
-      <th>Remark</th>
+      <th>Image</th>
+      <th>Name</th>
+      <th>Character</th>
+      <th>Category</th>
+
       <th colspan="3"></th>
     </tr>
   </thead>
 
   <tbody>
-    <% @wanted_items.each do |wanted_item| %>
+    <% @items.each do |item| %>
       <tr>
-        <td><%= wanted_item.quantity %></td>
-        <td><%= wanted_item.remark %></td>
+        <td><%= item.image %></td>
+        <td><%= item.name %></td>
+        <td><%= item.character %></td>
+        <td><%= item.category %></td>
       </tr>
     <% end %>
   </tbody>


### PR DESCRIPTION
ラベル以外は所持、欲しいアイテムにそれぞれ分けて表示できるようにした。
前回のコードだとアイテムと所持、欲しいアイテムの関連付けができていなかったためJavaScriptのコードを書き足して関連付けを行なった。